### PR TITLE
DONE: Refactor to not use async Promise executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@
 version: 2.1
 
 executors:
-  node10-browsers:
+  node-browsers:
     docker:
-      - image: circleci/node:18-browsers
+      - image: cmi/node:18.7.0-browsers
 
 jobs:
   setup:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - checkout
       - run: mkdir -p /tmp/workspace
@@ -25,19 +25,19 @@ jobs:
             - conf
             - package.json
   test-node:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:node
   test-browser:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:browser
   build:
-    executor: node10-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   node-browsers:
     docker:
-      - image: cmi/node:18.7.0-browsers
+      - image: cimg/node:18.7.0-browsers
 
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   node10-browsers:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:18-browsers
 
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   node-browsers:
     docker:
-      - image: cimg/node:18.7.0-browsers
+      - image: cimg/node:16.17-browsers
 
 jobs:
   setup:

--- a/src/index.js
+++ b/src/index.js
@@ -50,11 +50,9 @@ class Storage {
 
       // More backwards compatibility
 
-      db.status = db && db.status === "unknown-shim" ? "open" : db.status
+      db.status = db && db.status === 'unknown-shim' ? 'open' : db.status
 
       return store // should this not be db?
-
-
     } else {
       // Default leveldown or level-js store with directory creation
       if (fs && fs.mkdirSync) fs.mkdirSync(directory, { recursive: true })

--- a/src/index.js
+++ b/src/index.js
@@ -65,13 +65,9 @@ class Storage {
   }
 
   async destroy (store) {
-
     if (!this.storage.destory) return
 
     await this.storage.destory(store._db.location)
-
-    return
-
   }
 
   async preCreate (directory, options) {} // to be overridden

--- a/src/index.js
+++ b/src/index.js
@@ -64,18 +64,14 @@ class Storage {
     }
   }
 
-  destroy (store) {
-    return new Promise((resolve, reject) => {
-      // TODO: Clean this up
-      if (!this.storage.destroy) resolve()
+  async destroy (store) {
 
-      this.storage.destroy(store._db.location, (err) => {
-        if (err) {
-          return reject(err)
-        }
-        resolve()
-      })
-    })
+    if (!this.storage.destory) return
+
+    await this.storage.destory(store._db.location)
+
+    return
+
   }
 
   async preCreate (directory, options) {} // to be overridden

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ class Storage {
     this.options = { down: leveldownOptions }
   }
 
-  createStore (directory = './orbitdb', options = {}) {
+  async createStore (directory = './orbitdb', options = {}) {
     this.options.up = options
     await this.preCreate(directory, this.options)
     let store, db


### PR DESCRIPTION
Using async instead of the complex mix of new Promise and callbacks used at the moment in `createStore` and `destroy`.